### PR TITLE
fixing make compile settings for Linux aarch64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,11 @@ ifneq ($(filter arm%,$(ARCH)),)
   CFLAGS += -fsigned-char -marm
 endif
 
+ifeq ($(ARCH), aarch64)
+  CXX = g++               # clang/llvm 14 has a bug on Debian aarch64, so forcing g++
+  CFLAGS += -fsigned-char
+endif
+
 ifdef DEBUG
   CFLAGS += -O0 -g -D_DEBUG -DWDL_CHECK_FOR_NON_UTF8_FOPEN
 else


### PR DESCRIPTION
Added a few lines to the Makefile to get the plugin compiled on aarch64. (Raspberry Pis and similar devices, which Reaper has a version for)

This should not affect Windows or Mac builds at all, as they don't use the Makefile