### PR TITLE
Added Free Form Text Field to FX Mapping Advanced Edit Window

### DIFF
--- a/reaper_csurf_integrator/control_surface_integrator.h
+++ b/reaper_csurf_integrator/control_surface_integrator.h
@@ -500,6 +500,10 @@ private:
     void GetSteppedValues(Widget *widget, Action *action,  Zone *zone, int paramNumber, const vector<string> &params, const PropertyList &widgetProperties, double &deltaValue, vector<double> &acceleratedDeltaValues, double &rangeMinimum, double &rangeMaximum, vector<double> &steppedValues, vector<int> &acceleratedTickValues);
     void SetColor(const vector<string> &params, bool &supportsColor, bool &supportsTrackColor, vector<rgba_color> &colorValues);
     void GetColorValues(vector<rgba_color> &colorValues, const vector<string> &colors);
+
+    // ***** NEW: Free form text for FX assignment *****
+    std::string m_freeFormText;
+
 public:
     ActionContext(CSurfIntegrator *const csi, Action *action, Widget *widget, Zone *zone, int paramIndex, const vector<string> &params);
 
@@ -677,6 +681,9 @@ public:
         
         return buf;
     }
+    // ***** NEW: Free Form Text getter and setter *****
+    const char* GetFreeFormText() const { return m_freeFormText.c_str(); }
+    void SetFreeFormText(const char* text) { m_freeFormText = (text ? text : ""); }
 };
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/reaper_csurf_integrator/control_surface_integrator_ui.cpp
+++ b/reaper_csurf_integrator/control_surface_integrator_ui.cpp
@@ -408,6 +408,9 @@ static WDL_DLGRET dlgProcEditAdvanced(HWND hwndDlg, UINT uMsg, WPARAM wParam, LP
                 ticks += buf;
             }
             SetDlgItemText(hwndDlg, IDC_EDIT_TickValues, ticks.c_str());
+        
+            // NEW: Set the Free Form text field from the ActionContext.
+            SetDlgItemText(hwndDlg, IDC_EDIT_FREE_FORM, context->GetFreeFormText());
         }
             break;
             
@@ -457,6 +460,10 @@ static WDL_DLGRET dlgProcEditAdvanced(HWND hwndDlg, UINT uMsg, WPARAM wParam, LP
                         for (int i = 0; i < tokens.size(); ++i)
                             steps.push_back(atof(tokens[i].c_str()));
                         context->SetStepValues(steps);
+
+                        // NEW: Retrieve Free Form Text and store it in the ActionContext.
+                        GetDlgItemText(hwndDlg, IDC_EDIT_FREE_FORM, buf, sizeof(buf));
+                        context->SetFreeFormText(buf);
 
                         s_dlgResult = IDOK;
                         EndDialog(hwndDlg, 0);
@@ -763,6 +770,15 @@ static void SaveZone(SurfaceFXTemplate *t)
                             }
                             
                             fprintf(fxFile, " ]");
+
+                            // ***** NEW: Append free-form text for this assignment *****
+                            {
+                                const char* freeText = context->GetFreeFormText();
+                                if (freeText && freeText[0] != '\0')
+                                {
+                                    fprintf(fxFile, " %s", freeText);
+                                }
+                            }
                         }
                     }
                     

--- a/reaper_csurf_integrator/res.rc
+++ b/reaper_csurf_integrator/res.rc
@@ -186,26 +186,28 @@ BEGIN
     GROUPBOX        "Broadcasting",IDC_STATIC,7,8,393,144
 END
 
-IDD_DIALOG_EditAdvanced DIALOGEX 0, 0, 537, 149
+IDD_DIALOG_EditAdvanced DIALOGEX 0, 0, 537, 172
 STYLE DS_SETFONT | DS_MODALFRAME | DS_FIXEDSYS | WS_POPUP | WS_CAPTION | WS_SYSMENU
-CAPTION "Dialog"
+CAPTION "Edit Advanced FX Param"
 FONT 8, "MS Shell Dlg", 400, 0, 0x1
 BEGIN
-    EDITTEXT        IDC_EDIT_Delta,72,35,21,12,ES_AUTOHSCROLL
-    EDITTEXT        IDC_EDIT_RangeMin,386,35,21,12,ES_AUTOHSCROLL | WS_GROUP
-    EDITTEXT        IDC_EDIT_RangeMax,485,34,21,12,ES_AUTOHSCROLL
-    EDITTEXT        IDC_EDIT_DeltaValues,112,57,393,12,ES_AUTOHSCROLL
-    EDITTEXT        IDC_EDIT_TickValues,112,78,393,12,ES_AUTOHSCROLL
-    EDITTEXT        IDC_EditSteps,112,99,393,12,ES_AUTOHSCROLL
-    DEFPUSHBUTTON   "OK",IDOK,399,128,50,14
-    PUSHBUTTON      "Cancel",IDCANCEL,456,128,50,14
-    GROUPBOX        "FX Param Values",IDC_GroupFXParamValues,19,14,500,111
-    LTEXT           "Delta value",IDC_DeltaValueLabel,31,37,36,8
-    LTEXT           "Range minimum",IDC_RangeMinimumLabel,329,37,53,8
-    LTEXT           "Range maximum",IDC_RangeMaximumLabel,427,36,54,8
-    LTEXT           "Accelerated delta values",IDC_AcceleratedDeltaValuesLabel,28,59,76,8
-    LTEXT           "Accelerated tick values",IDC_AcceleratedTickValuesLabel,33,80,72,8
-    LTEXT           "Custom steps",IDC_StepsPromptGroup,41,101,43,8
+    GROUPBOX        "FX Param Values", IDC_GroupFXParamValues, 19, 14, 500, 140
+    LTEXT           "Delta value", IDC_DeltaValueLabel, 31, 35, 48, 12
+    EDITTEXT        IDC_EDIT_Delta, 72, 33, 40, 12, ES_AUTOHSCROLL
+    LTEXT           "Range minimum", IDC_RangeMinimumLabel, 329, 35, 53, 12
+    EDITTEXT        IDC_EDIT_RangeMin, 386, 33, 21, 12, ES_AUTOHSCROLL
+    LTEXT           "Range maximum", IDC_RangeMaximumLabel, 427, 35, 54, 12
+    EDITTEXT        IDC_EDIT_RangeMax, 485, 33, 21, 12, ES_AUTOHSCROLL
+    LTEXT           "Accelerated delta values", IDC_AcceleratedDeltaValuesLabel, 28, 59, 76, 8
+    EDITTEXT        IDC_EDIT_DeltaValues, 112, 57, 393, 12, ES_AUTOHSCROLL
+    LTEXT           "Accelerated tick values", IDC_AcceleratedTickValuesLabel, 33, 80, 72, 8
+    EDITTEXT        IDC_EDIT_TickValues, 112, 78, 393, 12, ES_AUTOHSCROLL
+    LTEXT           "Custom steps", IDC_StepsPromptGroup, 41, 101, 43, 8
+    EDITTEXT        IDC_EditSteps, 112, 99, 393, 12, ES_AUTOHSCROLL
+    LTEXT           "Free Form Text:", IDC_STATIC, 31, 120, 80, 12
+    EDITTEXT        IDC_EDIT_FREE_FORM, 112, 118, 393, 12, ES_AUTOHSCROLL
+    DEFPUSHBUTTON   "OK", IDOK, 399, 155, 50, 14
+    PUSHBUTTON      "Cancel", IDCANCEL, 456, 155, 50, 14
 END
 
 IDD_DIALOG_LearnFX DIALOGEX 0, 0, 282, 104

--- a/reaper_csurf_integrator/resource.h
+++ b/reaper_csurf_integrator/resource.h
@@ -124,6 +124,7 @@
 #define IDC_SurfaceName                 1304
 #define IDC_ApplyFontsAndMarginsToAll   1307
 #define IDC_GroupApplyToAll             1308
+#define IDC_EDIT_FREE_FORM              1309
 
 // Next default values for new objects
 // 


### PR DESCRIPTION
I added a "Free Form Text" field to the FX Learn Edit Advanced window. The intention for this field is that users can, directly from the GUI, do things like:

1. Add Feedback=No commands to an FX zone assignment
2. Add color toggle commands for surfaces like the MF Twister. E.g. { 255 50 0 90 255 0 }
3. Add trailing comments like "// 10 steps"
4. Have these get written to the FX Zone upon save at the end of the widget assignment row

The window itself was made larger to include the new field. While in there, I also made some of the existing text boxes wider, namely the Delta Value box, as that text was being cutoff in Windows.

Please review the changes in the Pull Request.

I confirmed it builds without errors and works here on my Windows machine.