### PR TITLE
Moved to TrackFX_SetParamNormalized and TrackFX_GetParamNormalized

### DIFF
--- a/reaper_csurf_integrator/control_surface_integrator_Reaper.h
+++ b/reaper_csurf_integrator/control_surface_integrator_Reaper.h
@@ -9,6 +9,8 @@
 
 #define WDL_NO_DEFINE_MINMAX
 
+#define REAPERAPI_WANT_TrackFX_GetParamNormalized
+#define REAPERAPI_WANT_TrackFX_SetParamNormalized
 #include "reaper_plugin_functions.h"
 
 using namespace std;

--- a/reaper_csurf_integrator/main.cpp
+++ b/reaper_csurf_integrator/main.cpp
@@ -1,6 +1,8 @@
 #define REAPERAPI_IMPLEMENT
 #define REAPERAPI_DECL
 
+#define REAPERAPI_WANT_TrackFX_GetParamNormalized
+#define REAPERAPI_WANT_TrackFX_SetParamNormalized
 #include "reaper_plugin_functions.h"
 #include "resource.h"
 


### PR DESCRIPTION
In order to fix CLAP and JSFX (likely AU too), this code moves CSI to use TrackFX_SetParamNormalized and TrackFX_GetParamNormalized versus the legacy, non-Normalized counterparts. The change impacts FXParam, FXAction, JSFXParam, TCPFXParam, and LastTouchedFXParam.

It builds, did a quick round of testing on all actions, and it works in Windows.

Note: there's a lot of legacy code in there as fallbacks as to 1) minimize the amount of code I'd have to change, but also 2) as not to break any existing functionality in case there are any circumstances where TrackFX_SetParamNormalized/TrackFX_GetParamNormalized wouldn't be available. 

@rwallingford and @higginsdragon , if you don't mind giving this a review, it would be appreciated.