### PR TITLE
Implement the folder view on the Track zone.

### DIFF
--- a/reaper_csurf_integrator/control_surface_Reaper_actions.h
+++ b/reaper_csurf_integrator/control_surface_Reaper_actions.h
@@ -3432,6 +3432,70 @@ public:
 };
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+class ToggleFolderView : public Action
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+{
+public:
+    virtual const char *GetName() override { return "ToggleFolderView"; }
+    
+    virtual void RequestUpdate(ActionContext* context) override
+    {
+        if (context->GetPage()->GetIsFolderViewActive())
+            context->UpdateWidgetValue(1.0);
+        else
+            context->UpdateWidgetValue(0.0);
+    }
+
+    virtual void Do(ActionContext* context, double value) override
+    {
+        if (value == 0.0) return; // ignore button releases
+
+        context->GetPage()->ToggleFolderView();
+    }
+};
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+class TrackSetCurrentFolder : public Action
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+{
+public:
+    virtual const char* GetName() override { return "TrackSetCurrentFolder"; }
+
+    virtual void RequestUpdate(ActionContext* context) override
+    {
+        context->UpdateColorValue(0.0);
+    }
+
+    virtual void Do(ActionContext* context, double value) override
+    {
+        if (value == 0.0) return; // ignore button releases
+
+        if (MediaTrack* track = context->GetTrack())
+            context->GetPage()->SetCurrentFolder(track);
+    }
+};
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+class SetParentFolderAsCurrent : public Action
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+{
+public:
+    virtual const char* GetName() override { return "SetParentFolderAsCurrent"; }
+
+    virtual void RequestUpdate(ActionContext* context) override
+    {
+        context->UpdateColorValue(0.0);
+    }
+
+    virtual void Do(ActionContext* context, double value) override
+    {
+        if (value == 0.0) return; // ignore button releases
+
+        context->GetPage()->SetParentFolderAsCurrent();
+    }
+};
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 class GlobalAutoModeDisplay : public Action
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 {

--- a/reaper_csurf_integrator/control_surface_Reaper_actions.h
+++ b/reaper_csurf_integrator/control_surface_Reaper_actions.h
@@ -3455,11 +3455,11 @@ public:
 };
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-class TrackSetCurrentFolder : public Action
+class TrackEnterFolder : public Action
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 {
 public:
-    virtual const char* GetName() override { return "TrackSetCurrentFolder"; }
+    virtual const char* GetName() override { return "TrackEnterFolder"; }
 
     virtual void RequestUpdate(ActionContext* context) override
     {
@@ -3476,11 +3476,11 @@ public:
 };
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-class SetParentFolderAsCurrent : public Action
+class ExitCurrentFolder : public Action
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 {
 public:
-    virtual const char* GetName() override { return "SetParentFolderAsCurrent"; }
+    virtual const char* GetName() override { return "ExitCurrentFolder"; }
 
     virtual void RequestUpdate(ActionContext* context) override
     {
@@ -3491,7 +3491,7 @@ public:
     {
         if (value == 0.0) return; // ignore button releases
 
-        context->GetPage()->SetParentFolderAsCurrent();
+        context->GetPage()->ExitCurrentFolder();
     }
 };
 

--- a/reaper_csurf_integrator/control_surface_integrator.cpp
+++ b/reaper_csurf_integrator/control_surface_integrator.cpp
@@ -3317,7 +3317,7 @@ void TrackNavigationManager::RebuildTracks()
             for (; trackID <= GetNumTracks(); trackID++)
             {
                 MediaTrack* track = CSurf_TrackFromID(trackID, followMCP_);
-                int depthOffset = GetMediaTrackInfo_Value(track, "I_FOLDERDEPTH");
+                int depthOffset = static_cast<int>(GetMediaTrackInfo_Value(track, "I_FOLDERDEPTH"));
 
                 if (trackID == currentFolderTrackID_)
                 {

--- a/reaper_csurf_integrator/control_surface_integrator.cpp
+++ b/reaper_csurf_integrator/control_surface_integrator.cpp
@@ -1059,8 +1059,8 @@ void CSurfIntegrator::InitActionsDictionary()
     actions_.insert(make_pair("TrackToggleFolderSpill", make_unique<TrackToggleFolderSpill>()));
     actions_.insert(make_pair("TrackFolderParentDisplay", make_unique<TrackFolderParentDisplay>()));
     actions_.insert(make_pair("ToggleFolderView", make_unique<ToggleFolderView>()));
-    actions_.insert(make_pair("TrackSetCurrentFolder", make_unique<TrackSetCurrentFolder>()));
-    actions_.insert(make_pair("SetParentFolderAsCurrent", make_unique<SetParentFolderAsCurrent>()));
+    actions_.insert(make_pair("TrackEnterFolder", make_unique<TrackEnterFolder>()));
+    actions_.insert(make_pair("ExitCurrentFolder", make_unique<ExitCurrentFolder>()));
     actions_.insert(make_pair("TrackSelect", make_unique<TrackSelect>()));
     actions_.insert(make_pair("TrackUniqueSelect", make_unique<TrackUniqueSelect>()));
     actions_.insert(make_pair("TrackRangeSelect", make_unique<TrackRangeSelect>()));

--- a/reaper_csurf_integrator/control_surface_integrator.cpp
+++ b/reaper_csurf_integrator/control_surface_integrator.cpp
@@ -3325,16 +3325,18 @@ void TrackNavigationManager::RebuildTracks()
                     {
                         trackID++; // The next track is the first one in the folder (a folder cannot be empty)
                     }
-                    else // The current track is not a folder (may happen is tracks were deleted for example)
+                    else // The currentFolderTrackID_ is not a folder actually
                     {
                         if (!ancestorStack.empty())
                         {
-                            trackID = GetIdFromTrack(ancestorStack.back()) + 1; // Back to last parent folder, next track is the first one in the folder
+                            currentFolderTrackID_ = GetIdFromTrack(ancestorStack.back()); // Back to last parent folder
+                            trackID = currentFolderTrackID_ + 1; // Next track is the first one in the folder
                             ancestorStack.pop_back();
                         }
                         else
                         {
-                            trackID = 1; // Back to the root level
+                            currentFolderTrackID_ = 0; // Back to the root level
+                            trackID = 1;
                         }
                     }
                     break;

--- a/reaper_csurf_integrator/control_surface_integrator.h
+++ b/reaper_csurf_integrator/control_surface_integrator.h
@@ -3037,7 +3037,7 @@ protected:
             // Find the selected track in the tracks_ list
             auto it = std::find(tracks_.begin(), tracks_.end(), selectedTrack);
             if (it != tracks_.end())
-                trackOffsetInList = std::distance(tracks_.begin(), it);
+                trackOffsetInList = static_cast<int>(std::distance(tracks_.begin(), it));
 
             if (trackOffsetInList < 0)
             {
@@ -3049,13 +3049,13 @@ protected:
                 // Find the selected track in the tracks_ list
                 auto it = std::find(tracks_.begin(), tracks_.end(), selectedTrack);
                 if (it != tracks_.end())
-                    trackOffsetInList = std::distance(tracks_.begin(), it);
+                    trackOffsetInList = static_cast<int>(std::distance(tracks_.begin(), it));
             }
 
             if (trackOffsetInList >= 0)
             {
                 int trackOffset = currentFolderTrackID_ + trackOffsetInList;
-                int maxOffset = tracks_.size() - trackNavigators_.size();
+                int maxOffset = static_cast<int>(tracks_.size() - trackNavigators_.size());
                 if (maxOffset < 0)
                     maxOffset = 0;
                 maxOffset += currentFolderTrackID_;

--- a/reaper_csurf_integrator/control_surface_integrator.h
+++ b/reaper_csurf_integrator/control_surface_integrator.h
@@ -3488,7 +3488,7 @@ public:
         trackOffset_ = currentFolderTrackID_;
     }
 
-    void SetParentFolderAsCurrent()
+    void ExitCurrentFolder()
     {
         SetCurrentFolder(parentOfCurrentFolderTrack_); // parentOfCurrentFolderTrack_ will be updated on track list rebuild
     }
@@ -3952,7 +3952,7 @@ public:
     void ToggleFolderView() { trackNavigationManager_->ToggleFolderView(); }
     bool GetIsFolderViewActive() { return trackNavigationManager_->GetIsFolderViewActive(); }
     void SetCurrentFolder(MediaTrack* track) { trackNavigationManager_->SetCurrentFolder(track); }
-    void SetParentFolderAsCurrent() { trackNavigationManager_->SetParentFolderAsCurrent(); }
+    void ExitCurrentFolder() { trackNavigationManager_->ExitCurrentFolder(); }
     void VCAModeActivated() { trackNavigationManager_->VCAModeActivated(); }
     void VCAModeDeactivated() { trackNavigationManager_->VCAModeDeactivated(); }
     void FolderModeActivated() { trackNavigationManager_->FolderModeActivated(); }

--- a/reaper_csurf_integrator/control_surface_integrator.h
+++ b/reaper_csurf_integrator/control_surface_integrator.h
@@ -535,7 +535,7 @@ private:
     bool provideFeedback_= true;
 
     string m_freeFormText;
-    
+
     PropertyList widgetProperties_;
         
     void UpdateTrackColor();
@@ -581,7 +581,7 @@ public:
     void SetIsFeedbackInverted() { isFeedbackInverted_ = true; }
     void SetHoldDelay(int value) { holdDelayMs_ = value; }
     int GetHoldDelay() { return holdDelayMs_; }
-    
+
     void SetAction(Action *action) { action_ = action; RequestUpdate(); }
     void DoAction(double value);
     void PerformAction(double value);
@@ -884,7 +884,7 @@ protected:
     double lastDoubleValue_ = 0.0;
     string lastStringValue_;
     rgba_color lastColor_;
-    
+
 public:
     FeedbackProcessor(CSurfIntegrator *const csi, Widget *widget) : csi_(csi), widget_(widget) {}
     virtual ~FeedbackProcessor() {}
@@ -897,7 +897,7 @@ public:
     virtual void ForceUpdateTrackColors() {}
     virtual void RunDeferredActions() {}
     virtual void ForceClear() {}
-    
+
     virtual void SetXTouchDisplayColors(const char *colors) {}
     virtual void RestoreXTouchDisplayColors() {}
 
@@ -911,7 +911,7 @@ public:
             ForceValue(properties, value);
         }
     }
-    
+
     virtual void SetValue(const PropertyList &properties, const char * const & value)
     {
         if (lastStringValue_ != value)
@@ -928,17 +928,17 @@ class Midi_FeedbackProcessor : public FeedbackProcessor
 {
 protected:
     Midi_ControlSurface *const surface_;
-    
+
     MIDI_event_ex_t lastMessageSent_;
     MIDI_event_ex_t midiFeedbackMessage1_;
     MIDI_event_ex_t midiFeedbackMessage2_;
-    
+
     Midi_FeedbackProcessor(CSurfIntegrator *const csi, Midi_ControlSurface *surface, Widget *widget) : FeedbackProcessor(csi, widget), surface_(surface) {}
-    
+
     Midi_FeedbackProcessor(CSurfIntegrator *const csi, Midi_ControlSurface *surface, Widget *widget, MIDI_event_ex_t feedback1) : FeedbackProcessor(csi, widget), surface_(surface), midiFeedbackMessage1_(feedback1) {}
-    
+
     Midi_FeedbackProcessor(CSurfIntegrator *const csi, Midi_ControlSurface *surface, Widget *widget, MIDI_event_ex_t feedback1, MIDI_event_ex_t feedback2) : FeedbackProcessor(csi, widget), surface_(surface), midiFeedbackMessage1_(feedback1), midiFeedbackMessage2_(feedback2) {}
-    
+
     void SendMidiSysExMessage(MIDI_event_ex_t *midiMessage);
     void SendMidiMessage(int first, int second, int third);
     void ForceMidiMessage(int first, int second, int third);
@@ -947,7 +947,7 @@ protected:
 public:
     ~Midi_FeedbackProcessor()
     { }
-    
+
     virtual const char *GetName() override { return "Midi_FeedbackProcessor"; }
 };
 
@@ -3020,33 +3020,40 @@ protected:
     
     void ForceScrollLink()
     {
-        // Make sure selected track is visble on the control surface
+        // Make sure selected track is visible on the control surface
         MediaTrack *selectedTrack = GetSelectedTrack();
         
         if (selectedTrack != NULL)
         {
+            // Is the selected track already visible
             for (auto &trackNavigator : trackNavigators_)
                 if (selectedTrack == trackNavigator->GetTrack())
                     return;
             
-            for (int i = 1; i <= GetNumTracks(); ++i)
+            // Find the selected track in the tracks_ list
+            int trackOffsetInList = 0;
+            bool found = false;
+            for (MediaTrack* track : tracks_)
             {
-                if (selectedTrack == GetTrackFromId(i))
+                if (track == selectedTrack)
                 {
-                    trackOffset_ = i - 1;
+                    found = true;
                     break;
                 }
+                ++trackOffsetInList;
             }
-            
-            trackOffset_ -= targetScrollLinkChannel_;
-            
-            if (trackOffset_ <  0)
-                trackOffset_ =  0;
-            
-            int top = GetNumTracks() - (int) trackNavigators_.size();
-            
-            if (trackOffset_ >  top)
-                trackOffset_ = top;
+
+            if (found)
+            {
+                int trackOffset = currentFolderTrackID_ + trackOffsetInList;
+                int maxOffset = tracks_.size() - trackNavigators_.size();
+                if (maxOffset < 0)
+                    maxOffset = 0;
+                maxOffset += currentFolderTrackID_;
+                if (trackOffset > maxOffset)
+                    trackOffset = maxOffset;
+                trackOffset_ = trackOffset;
+            }
         }
     }
     
@@ -4097,7 +4104,7 @@ public:
         if (pages_.size() > currentPageIndex_ && pages_[currentPageIndex_])
             pages_[currentPageIndex_]->ForceClear();
     }
-    
+
     void Shutdown()
     {
         // GAW -- IMPORTANT
@@ -4144,7 +4151,7 @@ public:
       if (size==8) return (double *)ret;
       return NULL;
     }
-    
+
     void Speak(const char *phrase)
     {
         static void (*osara_outputMessage)(const char *message);
@@ -4179,7 +4186,7 @@ public:
             return actions_["NoAction"].get();
         }
     }
-    
+
     void OnTrackSelection(MediaTrack *track) override
     {
         if (pages_.size() > currentPageIndex_ && pages_[currentPageIndex_])
@@ -4352,7 +4359,7 @@ public:
                 LogStackTraceToConsole();
             }
         }
-        
+
 
         /*
          repeats++;


### PR DESCRIPTION
Implement the folder view on the Track zone.

When this mode is activated, the tree-like structure of the tracks in REAPER is reflected on the MCU and you only see the children of a track. The idea behind this is that the folder structure corresponds to sub-mixes, and you can easily select and work on a single sub-mix or go back a step and mix only on the level of the sub-mixes. 
When you switch to folder view, only tracks are shown that have the Master track as their root. You can select these tracks as a current folder track by triggering the action TrackSetCurrentFolder. To move back to the parent root track, use the action SetParentFolderAsCurrent.

New actions:
- ToggleFolderView: engage (or disengage) this mode
- TrackSetCurrentFolder: set the selected track as current folder
- SetParentFolderAsCurrent: exit the current directory and go back up one level